### PR TITLE
feat: Add Discord link to Navbar

### DIFF
--- a/src/Navbar.css
+++ b/src/Navbar.css
@@ -19,7 +19,7 @@ nav a {
 	text-decoration: none;
 }
 
-nav > a:last-child {
+nav > a:nth-last-child(-n+2) {
 	display: flex;
 }
 

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -7,6 +7,7 @@ import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
+import SvgIcon from "@mui/material/SvgIcon";
 
 export default function Navbar() {
 	const [donateDialog, setDonateDialog] = useState(false);
@@ -27,6 +28,15 @@ export default function Navbar() {
 					target="_blank"
 				>
 					<GitHubIcon />
+				</a>
+				<a
+					href="https://discord.gg/4sCWj8Jy9m"
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					<SvgIcon viewBox="0 0 24 24">
+						<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.1 18.082.114 18.106.135 18.12a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+					</SvgIcon>
 				</a>
 			</nav>
 			<Dialog onClose={() => setDonateDialog(false)} open={donateDialog}>


### PR DESCRIPTION
This pull request enhances the navigation bar by adding a Discord link with an SVG icon and updates the CSS to ensure proper layout for the new set of navigation links.

**Navigation bar enhancements:**

* Added a new Discord link to the navigation bar, using a custom SVG icon for visual consistency. (`src/Navbar.js`)
* Imported `SvgIcon` from Material UI to support the new Discord SVG icon. (`src/Navbar.js`)

**Styling adjustments:**

* Updated the CSS selector in `Navbar.css` to apply flex display to the last two navigation links, ensuring the layout remains consistent with the new Discord link. (`src/Navbar.css`)