### PR TITLE
Temporarily disable Bedrooms and Family Rooms options

### DIFF
--- a/src/Alerts.js
+++ b/src/Alerts.js
@@ -20,6 +20,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Switch from "@mui/material/Switch";
 import TextField from "@mui/material/TextField";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { BEDROOMS_FAMILY_ROOMS_DISABLED } from "./featureFlags";
 
 dayjs.extend(utc);
 
@@ -30,6 +31,10 @@ const ACCOMMODATIONS = [
 	{ value: "bedroom", label: "Bedroom" },
 	{ value: "family_room", label: "Family Room" },
 ];
+
+const isAccommodationDisabled = (value) =>
+	BEDROOMS_FAMILY_ROOMS_DISABLED &&
+	(value === "bedroom" || value === "family_room");
 
 export default function Alerts() {
 	const [searchParams] = useSearchParams();
@@ -91,7 +96,9 @@ export default function Alerts() {
 		const a = searchParams.get("accommodation");
 		if (a) {
 			const match = ACCOMMODATIONS.find((opt) => opt.label === a);
-			if (match) setAccommodation(match.value);
+			if (match && !isAccommodationDisabled(match.value)) {
+				setAccommodation(match.value);
+			}
 		}
 		const p = searchParams.get("price");
 		if (p && !isNaN(parseFloat(p))) {
@@ -375,7 +382,11 @@ export default function Alerts() {
 							value={accommodation}
 						>
 							{ACCOMMODATIONS.map((opt) => (
-								<MenuItem key={opt.value} value={opt.value}>
+								<MenuItem
+									key={opt.value}
+									value={opt.value}
+									disabled={isAccommodationDisabled(opt.value)}
+								>
 									{opt.label}
 								</MenuItem>
 							))}

--- a/src/FareClassSelect.js
+++ b/src/FareClassSelect.js
@@ -6,6 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
 import Tooltip from "@mui/material/Tooltip";
+import { BEDROOMS_FAMILY_ROOMS_DISABLED } from "./featureFlags";
 
 export default function FareClassSelect({
 	value,
@@ -20,6 +21,11 @@ export default function FareClassSelect({
 	const [selected, setSelected] = useState(false);
 
 	useEffect(() => {
+		if (BEDROOMS_FAMILY_ROOMS_DISABLED) {
+			setBedrooms(false);
+			setFamilyRooms(false);
+			return;
+		}
 		setBedrooms(value === "Sleeper" || value === "Bedroom");
 		setFamilyRooms(value === "Sleeper" || value === "Family Room");
 	}, [value]);
@@ -44,7 +50,14 @@ export default function FareClassSelect({
 			variant={!searching ? "standard" : "outlined"}
 		>
 			{values.map((fareClass) => (
-				<MenuItem key={fareClass} value={fareClass}>
+				<MenuItem
+					key={fareClass}
+					value={fareClass}
+					disabled={
+						BEDROOMS_FAMILY_ROOMS_DISABLED &&
+						(fareClass === "Bedroom" || fareClass === "Family Room")
+					}
+				>
 					{fareClass.replace(/-/g, " ")}
 				</MenuItem>
 			))}

--- a/src/Form.js
+++ b/src/Form.js
@@ -12,6 +12,7 @@ import Settings from "./Settings";
 import StationSelect from "./StationSelect";
 import TravelerTypeSelect from "./TravelerTypeSelect";
 import RoundTripSelect from "./RoundTripSelect";
+import { BEDROOMS_FAMILY_ROOMS_DISABLED } from "./featureFlags";
 import "./Form.css";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
@@ -411,6 +412,7 @@ export default function Form({
 				setShowSearchErrors(true);
 			}, 0);
 		} else if (
+			!BEDROOMS_FAMILY_ROOMS_DISABLED &&
 			remindAddAccommsBool &&
 			!bedrooms &&
 			!familyRooms &&
@@ -762,7 +764,7 @@ export default function Form({
 						)}
 					</ButtonGroup>
 				)}
-				{errorType !== 1 && (
+				{!BEDROOMS_FAMILY_ROOMS_DISABLED && errorType !== 1 && (
 					<Dialog onClose={() => setSleeperOpen(false)} open={sleeperOpen}>
 						<DialogTitle>Additional Accommodations</DialogTitle>
 						<DialogContent>

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -7,6 +7,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
+import { BEDROOMS_FAMILY_ROOMS_DISABLED } from "./featureFlags";
 
 export default function Settings({
 	remindAddAccommsBool,
@@ -86,6 +87,7 @@ export default function Settings({
 						<span>Bedrooms</span>
 						<Switch
 							checked={bedrooms}
+							disabled={BEDROOMS_FAMILY_ROOMS_DISABLED}
 							onChange={() => setBedrooms(!bedrooms)}
 						/>
 					</div>
@@ -93,6 +95,7 @@ export default function Settings({
 						<span>Family Rooms</span>
 						<Switch
 							checked={familyRooms}
+							disabled={BEDROOMS_FAMILY_ROOMS_DISABLED}
 							onChange={() => setFamilyRooms(!familyRooms)}
 						/>
 					</div>

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,0 +1,7 @@
+// Feature flags for temporarily toggling functionality on or off.
+//
+// TEMPORARY: Bedrooms and Family Rooms are disabled while an issue is worked
+// out. Their options stay visible everywhere but are disabled, users are no
+// longer prompted about them, and searches never include them. Flip this back
+// to `false` to fully re-enable Bedrooms and Family Rooms.
+export const BEDROOMS_FAMILY_ROOMS_DISABLED = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Bedroom and Family Room selections across accommodation filters and settings.
  * Prevented disabled accommodation types from being applied through URL parameters.
  * Stopped additional accommodation prompts from appearing when these options are unavailable.
  * Ensured searches exclude disabled Bedroom and Family Room options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->